### PR TITLE
加入針對不同 Tag 設定顏色主題的功能

### DIFF
--- a/androidtagview/src/main/java/co/lujun/androidtagview/TagContainerLayout.java
+++ b/androidtagview/src/main/java/co/lujun/androidtagview/TagContainerLayout.java
@@ -119,7 +119,7 @@ public class TagContainerLayout extends ViewGroup {
     private int[] mViewPos;
 
     /** View theme(default PURE_CYAN)*/
-    private int mTheme = ColorFactory.PURE_CYAN;
+    private int mTheme = ColorTheme.ATTR_PURE_CYAN;
 
     /** Default interval(dp)*/
     private static final float DEFAULT_INTERVAL = 5;
@@ -779,7 +779,7 @@ public class TagContainerLayout extends ViewGroup {
             mColorFactory = new RandomColorFactory();
         } else if (colorTheme == ColorTheme.PURE_CYAN || colorTheme == ColorTheme.PURE_TEAL) {
             mColorFactory = new PureColorFactory(colorTheme);
-        } else if (colorTheme != ColorTheme.NONE) {
+        } else if (colorTheme != ColorTheme.CUSTOM) {
             mColorFactory = null;
             Log.e("TagContainerLayout", "ColorFactory not determined with theme set to " + theme);
         }

--- a/androidtagview/src/main/java/co/lujun/androidtagview/TagContainerLayout.java
+++ b/androidtagview/src/main/java/co/lujun/androidtagview/TagContainerLayout.java
@@ -9,6 +9,7 @@ import android.graphics.RectF;
 import android.graphics.Typeface;
 import android.support.v4.widget.ViewDragHelper;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.Gravity;
 import android.view.MotionEvent;
 import android.view.View;
@@ -17,6 +18,11 @@ import android.view.ViewGroup;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import co.lujun.androidtagview.colors.ColorFactory;
+import co.lujun.androidtagview.colors.ColorTheme;
+import co.lujun.androidtagview.colors.PureColorFactory;
+import co.lujun.androidtagview.colors.RandomColorFactory;
 
 /**
  * Author: lujun(http://blog.lujun.co)
@@ -121,6 +127,8 @@ public class TagContainerLayout extends ViewGroup {
     /** Default tag min length*/
     private static final int TAG_MIN_LENGTH = 3;
 
+    private ColorFactory mColorFactory;
+
     public TagContainerLayout(Context context) {
         this(context, null);
     }
@@ -184,6 +192,7 @@ public class TagContainerLayout extends ViewGroup {
         setTagMaxLength(mTagMaxLength);
         setTagHorizontalPadding(mTagHorizontalPadding);
         setTagVerticalPadding(mTagVerticalPadding);
+        setTheme(mTheme);
     }
 
     @Override
@@ -333,20 +342,6 @@ public class TagContainerLayout extends ViewGroup {
         return lines;
     }
 
-    private int[] onUpdateColorFactory(){
-        int[] colors;
-        if (mTheme == ColorFactory.RANDOM){
-            colors = ColorFactory.onRandomBuild();
-        }else if (mTheme == ColorFactory.PURE_TEAL){
-            colors = ColorFactory.onPureBuild(ColorFactory.PURE_COLOR.TEAL);
-        }else if (mTheme == ColorFactory.PURE_CYAN){
-            colors = ColorFactory.onPureBuild(ColorFactory.PURE_COLOR.CYAN);
-        }else {
-            colors = new int[]{mTagBackgroundColor, mTagBorderColor, mTagTextColor};
-        }
-        return colors;
-    }
-
     private void onSetTag(){
         if (mTags == null || mTags.size() == 0){
             return;
@@ -375,7 +370,7 @@ public class TagContainerLayout extends ViewGroup {
     }
 
     private void initTagView(TagView tagView){
-        int[] colors = onUpdateColorFactory();
+        int[] colors = mColorFactory.colorForTag(tagView.getText());
         tagView.setTagBackgroundColor(colors[0]);
         tagView.setTagBorderColor(colors[1]);
         tagView.setTagTextColor(colors[2]);
@@ -458,6 +453,10 @@ public class TagContainerLayout extends ViewGroup {
 
     private int ceilTagBorderWidth(){
         return (int)Math.ceil(mTagBorderWidth);
+    }
+
+    public void setColorFactory(ColorFactory colorFactory) {
+        this.mColorFactory = colorFactory;
     }
 
     private class DragHelperCallBack extends ViewDragHelper.Callback{
@@ -772,8 +771,18 @@ public class TagContainerLayout extends ViewGroup {
      * Set TagView theme.
      * @param theme
      */
-    public void setTheme(int theme){
+    public void setTheme(int theme) {
         mTheme = theme;
+
+        ColorTheme colorTheme = ColorTheme.getThemeFromAttr(theme);
+        if (colorTheme == ColorTheme.RANDOM) {
+            mColorFactory = new RandomColorFactory();
+        } else if (colorTheme == ColorTheme.PURE_CYAN || colorTheme == ColorTheme.PURE_TEAL) {
+            mColorFactory = new PureColorFactory(colorTheme);
+        } else if (colorTheme != ColorTheme.NONE) {
+            mColorFactory = null;
+            Log.e("TagContainerLayout", "ColorFactory not determined with theme set to " + theme);
+        }
     }
 
     /**

--- a/androidtagview/src/main/java/co/lujun/androidtagview/colors/ColorFactory.java
+++ b/androidtagview/src/main/java/co/lujun/androidtagview/colors/ColorFactory.java
@@ -1,0 +1,23 @@
+package co.lujun.androidtagview.colors;
+
+/**
+ * Author: lujun(http://blog.lujun.co)
+ * Date: 2016-1-4 23:20
+ */
+public interface ColorFactory {
+    /**
+     * ============= -->border color
+     * background color<---||-  Text --||-->text color
+     * =============
+     */
+
+    /**
+     * Fix color themes
+     */
+    public static final int NONE = -1;
+    public static final int RANDOM = 0;
+    public static final int PURE_CYAN = 1;
+    public static final int PURE_TEAL = 2;
+
+    int[] colorForTag(final String tag);
+}

--- a/androidtagview/src/main/java/co/lujun/androidtagview/colors/ColorFactory.java
+++ b/androidtagview/src/main/java/co/lujun/androidtagview/colors/ColorFactory.java
@@ -11,13 +11,5 @@ public interface ColorFactory {
      * =============
      */
 
-    /**
-     * Fix color themes
-     */
-    public static final int NONE = -1;
-    public static final int RANDOM = 0;
-    public static final int PURE_CYAN = 1;
-    public static final int PURE_TEAL = 2;
-
     int[] colorForTag(final String tag);
 }

--- a/androidtagview/src/main/java/co/lujun/androidtagview/colors/ColorTheme.java
+++ b/androidtagview/src/main/java/co/lujun/androidtagview/colors/ColorTheme.java
@@ -1,0 +1,32 @@
+package co.lujun.androidtagview.colors;
+
+/**
+ * Created by egistli on 2016/1/20.
+ */
+public enum ColorTheme {
+    NONE(""),
+    RANDOM("R0NDAM"),
+    PURE_TEAL("009688"),
+    PURE_CYAN("00BCD4");
+
+    private final String colorHex;
+
+    ColorTheme(final String colorHex) {
+        this.colorHex = colorHex;
+    }
+
+    public static ColorTheme getThemeFromAttr(int theme) {
+        if (theme == 0) {
+            return RANDOM;
+        } else if (theme == 1) {
+            return PURE_TEAL;
+        } else if (theme == 2) {
+            return PURE_CYAN;
+        }
+        return NONE;
+    }
+
+    public String getColorHex() {
+        return colorHex;
+    }
+}

--- a/androidtagview/src/main/java/co/lujun/androidtagview/colors/ColorTheme.java
+++ b/androidtagview/src/main/java/co/lujun/androidtagview/colors/ColorTheme.java
@@ -4,10 +4,15 @@ package co.lujun.androidtagview.colors;
  * Created by egistli on 2016/1/20.
  */
 public enum ColorTheme {
-    NONE(""),
+    CUSTOM(""),
     RANDOM("R0NDAM"),
     PURE_TEAL("009688"),
     PURE_CYAN("00BCD4");
+
+    public static final int ATTR_CUSTOM = -1;
+    public static final int ATTR_RANDOM = 0;
+    public static final int ATTR_PURE_CYAN = 1;
+    public static final int ATTR_PURE_TEAL = 2;
 
     private final String colorHex;
 
@@ -16,14 +21,14 @@ public enum ColorTheme {
     }
 
     public static ColorTheme getThemeFromAttr(int theme) {
-        if (theme == 0) {
+        if (theme == ATTR_RANDOM) {
             return RANDOM;
-        } else if (theme == 1) {
+        } else if (theme == ATTR_PURE_TEAL) {
             return PURE_TEAL;
-        } else if (theme == 2) {
+        } else if (theme == ATTR_PURE_CYAN) {
             return PURE_CYAN;
         }
-        return NONE;
+        return CUSTOM;
     }
 
     public String getColorHex() {

--- a/androidtagview/src/main/java/co/lujun/androidtagview/colors/PureColorFactory.java
+++ b/androidtagview/src/main/java/co/lujun/androidtagview/colors/PureColorFactory.java
@@ -1,0 +1,32 @@
+package co.lujun.androidtagview.colors;
+
+import android.graphics.Color;
+
+/**
+ * Created by egistli on 2016/1/20.
+ */
+public class PureColorFactory implements ColorFactory {
+    private static final String BG_COLOR_ALPHA = "33";
+    private static final String BD_COLOR_ALPHA = "88";
+    private static final int SHARP727272 = Color.parseColor("#FF727272");
+
+    private String color;
+    private int[] colors;
+
+    public PureColorFactory(final ColorTheme theme) {
+        this.color = theme.getColorHex();
+        cacheColors();
+    }
+
+    private void cacheColors() {
+        int bgColor = Color.parseColor("#" + BG_COLOR_ALPHA + color);
+        int bdColor = Color.parseColor("#" + BD_COLOR_ALPHA + color);
+        int tColor = SHARP727272;
+        colors = new int[]{bgColor, bdColor, tColor};
+    }
+
+    @Override
+    public int[] colorForTag(final String tag) {
+        return colors;
+    }
+}

--- a/androidtagview/src/main/java/co/lujun/androidtagview/colors/RandomColorFactory.java
+++ b/androidtagview/src/main/java/co/lujun/androidtagview/colors/RandomColorFactory.java
@@ -1,22 +1,11 @@
-package co.lujun.androidtagview;
+package co.lujun.androidtagview.colors;
 
 import android.graphics.Color;
 
 /**
- * Author: lujun(http://blog.lujun.co)
- * Date: 2016-1-4 23:20
+ * Created by egistli on 2016/1/20.
  */
-public class ColorFactory {
-
-    /**
-     *                       ============= -->border color
-     *  background color<---||-  Text --||-->text color
-     *                      =============
-     */
-
-    public static final String BG_COLOR_ALPHA = "33";
-    public static final String BD_COLOR_ALPHA = "88";
-
+public class RandomColorFactory implements ColorFactory {
     public static final String RED = "F44336";
     public static final String LIGHTBLUE = "03A9F4";
     public static final String AMBER = "FFC107";
@@ -31,33 +20,21 @@ public class ColorFactory {
     public static final String TEAL = "009688";
     public static final String CYAN = "00BCD4";
 
-    public enum PURE_COLOR{CYAN, TEAL}
-
-    public static final int NONE = -1;
-    public static final int RANDOM = 0;
-    public static final int PURE_CYAN = 1;
-    public static final int PURE_TEAL = 2;
-
     public static final int SHARP666666 = Color.parseColor("#FF666666");
-    public static final int SHARP727272 = Color.parseColor("#FF727272");
+
+    private static final String BG_COLOR_ALPHA = "33";
+    private static final String BD_COLOR_ALPHA = "88";
 
     private static final String[] COLORS = new String[]{RED, LIGHTBLUE, AMBER, ORANGE, YELLOW,
             LIME, BLUE, INDIGO, LIGHTGREEN, GREY, DEEPPURPLE, TEAL, CYAN};
 
-    public static int[] onRandomBuild(){
+    @Override
+    public int[] colorForTag(final String tag) {
+        // RandomColorFactory ignores tag passed in
         int random = (int)(Math.random() * COLORS.length);
         int bgColor = Color.parseColor("#" + BG_COLOR_ALPHA + COLORS[random]);
         int bdColor = Color.parseColor("#" + BD_COLOR_ALPHA + COLORS[random]);
         int tColor = SHARP666666;
         return new int[]{bgColor, bdColor, tColor};
     }
-
-    public static int[] onPureBuild(PURE_COLOR type){
-        String color = type == PURE_COLOR.CYAN ? CYAN : TEAL;
-        int bgColor = Color.parseColor("#" + BG_COLOR_ALPHA + color);
-        int bdColor = Color.parseColor("#" + BD_COLOR_ALPHA + color);
-        int tColor = SHARP727272;
-        return new int[]{bgColor, bdColor, tColor};
-    }
-
 }

--- a/androidtagview/src/main/res/values/attrs.xml
+++ b/androidtagview/src/main/res/values/attrs.xml
@@ -28,12 +28,12 @@
         <attr name="tag_max_length" format="integer" />
         <attr name="tag_clickable" format="boolean" />
         <attr name="tag_theme" format="enum">
-            <enum name="none" value="-1" />
+            <enum name="custom" value="-1" />
             <enum name="random" value="0" />
             <enum name="pure_cyan" value="1" />
             <enum name="pure_teal" value="2" />
         </attr>
-        <attr name="tag_text_direction" format="enum" >
+        <attr name="tag_text_direction" format="enum">
             <enum name="ltr" value="3" />
             <enum name="rtl" value="4" />
         </attr>

--- a/sample/src/main/java/co/lujun/sample/MainActivity.java
+++ b/sample/src/main/java/co/lujun/sample/MainActivity.java
@@ -2,7 +2,7 @@ package co.lujun.sample;
 
 import android.app.AlertDialog;
 import android.content.DialogInterface;
-import android.graphics.Typeface;
+import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
@@ -16,10 +16,11 @@ import java.util.List;
 
 import co.lujun.androidtagview.TagContainerLayout;
 import co.lujun.androidtagview.TagView;
+import co.lujun.androidtagview.colors.ColorFactory;
 
 public class MainActivity extends AppCompatActivity {
 
-    private TagContainerLayout mTagContainerLayout1, mTagContainerLayout2, mTagContainerLayout3, mTagContainerLayout4;
+    private TagContainerLayout mTagContainerLayout1, mTagContainerLayout2, mTagContainerLayout3, mTagContainerLayout4, mTagContainerLayout5;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -56,11 +57,35 @@ public class MainActivity extends AppCompatActivity {
 
         String[] list3 = new String[]{"Persian", "波斯语", "فارسی", "Hello", "你好", "سلام"};
         String[] list4 = new String[]{"Adele", "Whitney Houston"};
+        String[] list5 = new String[]{"Apple", "Asparagus", "Banana", "Brunch", "Candy", "Cake", "Donuts"};
 
         mTagContainerLayout1 = (TagContainerLayout) findViewById(R.id.tagcontainerLayout1);
         mTagContainerLayout2 = (TagContainerLayout) findViewById(R.id.tagcontainerLayout2);
         mTagContainerLayout3 = (TagContainerLayout) findViewById(R.id.tagcontainerLayout3);
         mTagContainerLayout4 = (TagContainerLayout) findViewById(R.id.tagcontainerLayout4);
+        mTagContainerLayout5 = (TagContainerLayout) findViewById(R.id.tagcontainerLayout5);
+
+        mTagContainerLayout5.setColorFactory(new ColorFactory() {
+            @Override
+            public int[] colorForTag(String tag) {
+                String themeColorHex;
+                if (tag.startsWith("A")) {
+                    themeColorHex = "FF0000";
+                } else if (tag.startsWith("B")) {
+                    themeColorHex = "00FF00";
+                } else if (tag.startsWith("C")){
+                    themeColorHex = "0000FF";
+                } else {
+                    themeColorHex = "000000";
+                }
+
+                int[] colors = new int[3];
+                colors[0] = Color.parseColor("#33" + themeColorHex);
+                colors[1] = Color.parseColor("#88" + themeColorHex);
+                colors[2] = Color.parseColor("#FFFFFF");
+                return colors;
+            }
+        });
 
         // Set custom click listener
         mTagContainerLayout1.setOnTagClickListener(new TagView.OnTagClickListener() {
@@ -115,6 +140,7 @@ public class MainActivity extends AppCompatActivity {
         mTagContainerLayout2.setTags(list2);
         mTagContainerLayout3.setTags(list3);
         mTagContainerLayout4.setTags(list4);
+        mTagContainerLayout5.setTags(list5);
 
         final EditText text = (EditText) findViewById(R.id.text_tag);
         Button btnAddTag = (Button) findViewById(R.id.btn_add_tag);

--- a/sample/src/main/java/co/lujun/sample/MainActivity.java
+++ b/sample/src/main/java/co/lujun/sample/MainActivity.java
@@ -123,8 +123,8 @@ public class MainActivity extends AppCompatActivity {
         // Set the custom theme
 //        mTagContainerLayout1.setTheme(ColorFactory.PURE_CYAN);
 
-        // If you want to use your colors for TagView, remember set the theme with ColorFactory.NONE
-//        mTagContainerLayout1.setTheme(ColorFactory.NONE);
+        // If you want to use your colors for TagView, remember set the theme with ColorFactory.CUSTOM
+//        mTagContainerLayout1.setTheme(ColorFactory.CUSTOM);
 //        mTagContainerLayout1.setTagBackgroundColor(Color.TRANSPARENT);
 //        mTagContainerLayout1.setTagTextDirection(View.TEXT_DIRECTION_RTL);
 

--- a/sample/src/main/res/layout/content_main.xml
+++ b/sample/src/main/res/layout/content_main.xml
@@ -90,7 +90,7 @@
                 app:tag_text_color="#ff666666"
                 app:tag_text_direction="rtl"
                 app:tag_text_size="14sp"
-                app:tag_theme="none"
+                app:tag_theme="pure_teal"
                 app:tag_vertical_padding="10dp"
                 app:vertical_interval="10dp" />
 
@@ -105,6 +105,19 @@
                 app:horizontal_interval="10dp"
                 app:tag_clickable="true"
                 app:tag_theme="pure_teal"
+                app:vertical_interval="10dp" />
+
+            <co.lujun.androidtagview.TagContainerLayout
+                android:id="@+id/tagcontainerLayout5"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:padding="10dp"
+                app:container_enable_drag="false"
+                app:container_gravity="center"
+                app:horizontal_interval="10dp"
+                app:tag_clickable="true"
+                app:tag_theme="none"
                 app:vertical_interval="10dp" />
 
         </LinearLayout>

--- a/sample/src/main/res/layout/content_main.xml
+++ b/sample/src/main/res/layout/content_main.xml
@@ -90,7 +90,6 @@
                 app:tag_text_color="#ff666666"
                 app:tag_text_direction="rtl"
                 app:tag_text_size="14sp"
-                app:tag_theme="pure_teal"
                 app:tag_vertical_padding="10dp"
                 app:vertical_interval="10dp" />
 
@@ -117,7 +116,7 @@
                 app:container_gravity="center"
                 app:horizontal_interval="10dp"
                 app:tag_clickable="true"
-                app:tag_theme="none"
+                app:tag_theme="custom"
                 app:vertical_interval="10dp" />
 
         </LinearLayout>


### PR DESCRIPTION
嗨，先謝謝您寫這個 library，很簡潔好用。

不過在我的使用情境下，需要針對不同的 tag 上不同的顏色。例如：『免費』tag 要是綠色、『特選』tag 要是金色...等。

目前的架構 tag 主題顏色的設定是由 TagContainerLayout 直接依照 `theme` 屬性設定給 TagView 的，所以我的寫法依然把這部分的職責留在 TagContainerLayout，但把決定顏色的工作由可以抽換的 ColorFactory 的實作類別來進行。

要自訂 tag 上色邏輯，只要在 xml 把 `app:tag_theme` 設為 `custom`，並在程式內設定 custom colorFactory 給 TabContainerLayout 即可。

最後一個修改把 NONE 這個屬性換成 CUSTOM 的原因是，其實沒有所謂 NONE 這種 theme，即便 xml 內設定為 NONE ，其實主題是預設的 teal。因此我把 NONE 改成自定義上色邏輯專用的 CUSTOM，希望這樣子 theme 的設定會更清楚。